### PR TITLE
Fixing enviornment issues still left after copying BaseFileServer. 

### DIFF
--- a/DutchTreat/DutchTreat.csproj
+++ b/DutchTreat/DutchTreat.csproj
@@ -4,8 +4,4 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="wwwroot\index.html" />
-  </ItemGroup>
-
 </Project>

--- a/DutchTreat/DutchTreat.sln
+++ b/DutchTreat/DutchTreat.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30804.86
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DutchTreat", "DutchTreat.csproj", "{C1D8A605-AEFB-4839-B6F2-EFB3E0054EC8}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DutchTreat", "DutchTreat.csproj", "{C020AF70-5746-4949-8BD6-0A23C5F1B337}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -11,15 +11,15 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{C1D8A605-AEFB-4839-B6F2-EFB3E0054EC8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C1D8A605-AEFB-4839-B6F2-EFB3E0054EC8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C1D8A605-AEFB-4839-B6F2-EFB3E0054EC8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C1D8A605-AEFB-4839-B6F2-EFB3E0054EC8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C020AF70-5746-4949-8BD6-0A23C5F1B337}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C020AF70-5746-4949-8BD6-0A23C5F1B337}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C020AF70-5746-4949-8BD6-0A23C5F1B337}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C020AF70-5746-4949-8BD6-0A23C5F1B337}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {F1983FA5-DD24-48B5-B595-25EA53191F24}
+		SolutionGuid = {44EEA707-896E-4F6C-B291-17D2A0FFFFE4}
 	EndGlobalSection
 EndGlobal

--- a/DutchTreat/Properties/launchSettings.json
+++ b/DutchTreat/Properties/launchSettings.json
@@ -1,9 +1,9 @@
-{
+﻿{
   "iisSettings": {  // Used when run as IIS service.
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:61599",
+      "applicationUrl": "http://localhost:51608",
       "sslPort": 0
     }
   },
@@ -18,10 +18,10 @@
     "DutchTreat": { // Used when run as executable service.
       "commandName": "Project",
       "launchBrowser": true,
+      "applicationUrl": "http://localhost:8888",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      },
-      "applicationUrl": "http://localhost:8888"
+      }
     }
   }
 }


### PR DESCRIPTION
Solution/project files were causing IIS server to serve a stale index page, as if no changes had been made recently, while the executable service worked fine. Fixed this by recreating a new project from scratch and copying over file contents. 

I suspect the issue might have just been the ItemGroup in the project file for the index page. Removing that fixed this most likely. Still glad to have the GUIDs unique from other solutions.